### PR TITLE
Set WAYLAND_DISPLAY if started by simple-wrapper

### DIFF
--- a/data/com.system76.CosmicLauncher.desktop
+++ b/data/com.system76.CosmicLauncher.desktop
@@ -10,3 +10,4 @@ Keywords=Gnome;GTK;
 Icon=com.system76.CosmicLauncher
 StartupNotify=true
 NoDisplay=true
+HostWaylandDisplay=true

--- a/src/desktop_entry_data.rs
+++ b/src/desktop_entry_data.rs
@@ -112,6 +112,11 @@ impl DesktopEntryData {
                 .spawn()
                 .map_err(anyhow::Error::msg)
         } else {
+            let wayland_display = if let Ok(display) = std::env::var("HOST_WAYLAND_DISPLAY") {
+                Some(("WAYLAND_DISPLAY", display))
+            } else {
+                None
+            };
             Command::new("gtk-launch")
                 .arg(
                     imp::DesktopEntryData::from_instance(self)
@@ -119,6 +124,7 @@ impl DesktopEntryData {
                         .borrow()
                         .clone(),
                 )
+                .envs(wayland_display)
                 .spawn()
                 .map_err(anyhow::Error::msg)
         }


### PR DESCRIPTION
Fixes starting applications on pure wayland desktops, if cosmic-launcher is used via simple-wrapper.