### PR TITLE
Detach spawned processes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.check.overrideCommand": ["just", "check-json"]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "i18n-embed-fl",
  "libcosmic",
  "log",
+ "nix 0.26.2",
  "once_cell",
  "pop-launcher",
  "pop-launcher-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ zbus = "3.7.0"
 glob = "0.3.1"
 freedesktop-desktop-entry = "0.5.0"
 shlex = "1.1.0"
-
+nix = "0.26.2"

--- a/justfile
+++ b/justfile
@@ -11,6 +11,15 @@ export INSTALL_DIR := base-dir / 'share'
 bin-src := 'target' / 'release' / name
 bin-dst := base-dir / 'bin' / name
 
+# Use lld linker if available
+ld-args := if `which lld || true` != '' {
+    '-C link-arg=-fuse-ld=lld -C link-arg=-Wl,--build-id=sha1 -Clink-arg=-Wl,--no-rosegment'
+} else {
+    ''
+}
+
+export RUSTFLAGS := env_var_or_default('RUSTFLAGS', '') + ' ' + ld-args
+
 # Default recipe which runs `just build-release`
 default: build-release
 

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -153,7 +153,7 @@ impl Application for CosmicLauncher {
                                 };
                                 let mut cmd = match exec.next() {
                                     Some(cmd) if !cmd.contains("=") => {
-                                        tokio::process::Command::new(cmd)
+                                        std::process::Command::new(cmd)
                                     }
                                     _ => return Command::none(),
                                 };
@@ -163,7 +163,7 @@ impl Application for CosmicLauncher {
                                         cmd.arg(arg);
                                     }
                                 }
-                                let _ = cmd.spawn();
+                                crate::process::spawn(cmd);
                                 return Command::perform(async {}, |_| Message::Hide);
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod components;
 #[rustfmt::skip]
 mod config;
 mod localize;
+mod process;
 mod subscriptions;
 use config::APP_ID;
 use log::info;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use nix::sys::wait::waitpid;
+use nix::unistd::{fork, ForkResult};
+use std::process::{exit, Command, Stdio};
+
+pub fn spawn(mut command: Command) {
+    unsafe {
+        match fork().expect("failed to fork process") {
+            ForkResult::Parent { child } => {
+                waitpid(Some(child), None).unwrap();
+            }
+
+            ForkResult::Child => {
+                let _res = nix::unistd::setsid();
+                let _res = command
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn();
+                exit(0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This'll ensure that the lifetime of spawned applications is not tied to the cosmic-launcher process.
Can be tested by launching some applications from the launcher and then killing the launcher process.