### PR TITLE
Close pop-launcher processes on hide, and fix cosmic-launcher exiting on close message

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -14,7 +14,7 @@ use cosmic::iced::wayland::layer_surface::{
 };
 use cosmic::iced::wayland::InitialSurface;
 use cosmic::iced::widget::{button, column, container, text, text_input, Column};
-use cosmic::iced::{self, executor, Application, Command, Length, Subscription};
+use cosmic::iced::{self, Application, Command, Length, Subscription};
 use cosmic::iced_runtime::core::event::wayland::LayerEvent;
 use cosmic::iced_runtime::core::event::{wayland, PlatformSpecific};
 use cosmic::iced_runtime::core::layout::Limits;
@@ -71,7 +71,7 @@ enum Message {
 impl Application for CosmicLauncher {
     type Message = Message;
     type Theme = Theme;
-    type Executor = executor::Default;
+    type Executor = cosmic::executor::single::Executor;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::process::exit;
 
 use crate::config;
 use crate::subscriptions::launcher::{launcher, LauncherEvent, LauncherRequest};
@@ -157,9 +156,7 @@ impl Application for CosmicLauncher {
                     });
                 }
                 LauncherEvent::Response(response) => match response {
-                    pop_launcher::Response::Close => {
-                        exit(0);
-                    },
+                    pop_launcher::Response::Close => return self.hide(),
                     pop_launcher::Response::Context { .. } => {
                         // TODO ASHLEY
                     }

--- a/src/subscriptions/launcher.rs
+++ b/src/subscriptions/launcher.rs
@@ -1,105 +1,95 @@
-use cosmic::iced::futures::{channel::mpsc, StreamExt};
-use futures::Stream;
-use pop_launcher::{Request, Response};
-use std::{hash::Hash, pin::Pin};
+use cosmic::{iced::futures::{channel::mpsc, StreamExt}, iced_runtime::futures::MaybeSend};
+use futures::{Stream, SinkExt};
+use pop_launcher::Request;
+use pop_launcher_service::IpcClient;
+use std::hash::Hash;
 
 #[derive(Debug, Clone)]
 pub enum LauncherRequest {
     Search(String),
     Activate(u32),
+    Close,
 }
 
 #[derive(Debug, Clone)]
 pub enum LauncherEvent {
     Started(mpsc::Sender<LauncherRequest>),
     Response(pop_launcher::Response),
-    Error(String),
 }
 
 pub fn launcher<I: 'static + Hash + Copy + Send + Sync>(
     id: I,
-) -> cosmic::iced::Subscription<(I, LauncherEvent)> {
+) -> cosmic::iced::Subscription<LauncherEvent> {
     use cosmic::iced::subscription;
 
-    subscription::unfold(id, State::Ready, move |state| _launcher(id, state))
-}
-
-async fn _launcher<I: Copy>(id: I, state: State) -> ((I, LauncherEvent), State) {
-    match state {
-        State::Ready => {
-            if let Ok(launcher_ipc) = LauncherIpc::new() {
-                (
-                    (id, LauncherEvent::Started(launcher_ipc.get_sender())),
-                    State::Waiting(launcher_ipc),
-                )
-            } else {
-                (
-                    (
-                        id,
-                        LauncherEvent::Error("Failed to start the ipc client".to_string()),
-                    ),
-                    State::Error,
-                )
+    subscription::channel(id, 1, |mut output| async move {
+        loop {
+            log::info!("starting pop-launcher service");
+            let mut responses = service();
+            while let Some(message) = responses.next().await {
+                let _res = output.send(message).await;
             }
         }
-        State::Waiting(mut rx) => {
-            if let Some(response) = rx.results().await {
-                (
-                    (id, LauncherEvent::Response(response)),
-                    State::Waiting(rx),
-                )
-            } else {
-                (
-                    (
-                        id,
-                        LauncherEvent::Error("channel for ipc client was closed".to_string()),
-                    ),
-                    State::Error,
-                )
-            }
-        }
-        State::Error => cosmic::iced::futures::future::pending().await,
-    }
+    })
 }
 
-pub enum State {
-    Ready,
-    Waiting(LauncherIpc),
-    Error,
-}
+/// Initializes pop-launcher if it is not running, and returns a handle to its client.
+fn client_request<'a>(tx: &mpsc::Sender<LauncherEvent>, client: &'a mut Option<IpcClient>) -> &'a mut Option<IpcClient> {
+    if client.is_none() {
+        *client = match pop_launcher_service::IpcClient::new() {
+            Ok((new_client, responses)) => {
+                let mut tx = tx.clone();
 
-pub struct LauncherIpc {
-    ipc_rx: Pin<Box<dyn Stream<Item = Response> + Send>>,
-    tx: mpsc::Sender<LauncherRequest>,
-}
-
-impl LauncherIpc {
-    pub fn new() -> anyhow::Result<Self> {
-        let (mut ipc_tx, ipc_rx) = pop_launcher_service::IpcClient::new()?;
-        let (tx, mut rx) = mpsc::channel(100);
-        tokio::spawn(async move {
-            while let Some(req) = rx.next().await {
-                match req {
-                    LauncherRequest::Search(s) => {
-                        let _ = ipc_tx.send(Request::Search(s)).await;
+                tokio::spawn(async move {
+                    let mut responses = std::pin::pin!(responses);
+                    while let Some(response) = responses.next().await {
+                        let _res = tx.send(LauncherEvent::Response(response)).await;
                     }
-                    LauncherRequest::Activate(i) => {
-                        let _ = ipc_tx.send(Request::Activate(i)).await;
+                });
+
+                Some(new_client)
+            },
+            Err(why) => {
+                log::error!("pop-launcher failed to start: {}", why);
+                None
+            }
+        }
+    };
+
+    client
+}
+
+pub fn service() -> impl Stream<Item = LauncherEvent> + MaybeSend {
+    let (requests_tx, mut requests_rx) = mpsc::channel(4);
+    let (mut responses_tx, responses_rx) = mpsc::channel(4);
+
+    tokio::spawn(async move {
+        let _res = responses_tx.send(LauncherEvent::Started(requests_tx.clone())).await;
+
+        let client = &mut None;
+
+        while let Some(request) = requests_rx.next().await {
+            match request {
+                LauncherRequest::Search(s) => {
+                    if let Some(client) = client_request(&responses_tx, client) {
+                        let _res = client.send(Request::Search(s)).await;
+                    }
+                }
+                LauncherRequest::Activate(i) => {
+                    if let Some(client) = client_request(&responses_tx, client) {
+                        let _res = client.send(Request::Activate(i)).await;
+                    }
+                }
+                LauncherRequest::Close => {
+                    if let Some(mut client) = client.take() {
+                        log::info!("closing pop-launcher service");
+                        let _res = client.child.kill().await;
+                        let _res = client.child.wait().await;
                     }
                 }
             }
-        });
-        Ok(Self {
-            ipc_rx: Box::pin(ipc_rx),
-            tx,
-        })
-    }
+        }
+    });
 
-    pub fn get_sender(&self) -> mpsc::Sender<LauncherRequest> {
-        self.tx.clone()
-    }
-
-    pub async fn results(&mut self) -> Option<Response> {
-        self.ipc_rx.next().await
-    }
+    responses_rx
 }


### PR DESCRIPTION
- Changed the way the pop-launcher subscription is managed so that it can restart itself.
- Hiding the launcher will now close the pop-launcher processes.
- On receive of the close message from pop-launcher, pop-launcher will be closed instead of cosmic-launcher
- Switched to the single-threaded tokio executor from libcosmic.

This may fix the issue where the pop-launcher process is no longer started by cosmic-session after it exits a few times.