### PR TITLE
Add chinese translation

### DIFF
--- a/i18n/zh-cn/cosmic_launcher.ftl
+++ b/i18n/zh-cn/cosmic_launcher.ftl
@@ -1,0 +1,1 @@
+app-name = Cosmic 启动器

--- a/i18n/zh-tw/cosmic_launcher.ftl
+++ b/i18n/zh-tw/cosmic_launcher.ftl
@@ -1,0 +1,1 @@
+app-name = Cosmic 啟動器


### PR DESCRIPTION
The translation for launcher in Chinese is called 啟動器，my source for this translation is found from the simplified chinese version of the arch wiki for dmenu

> dmenu是一个X下的快速、轻量级的软件启动器... - https://wiki.archlinuxcn.org/zh/Dmenu

which translates to "dmenu is a quick and lightweight launcher running under X..."

There are two folders created, as chinese characters have two main writing styles — simplified (zh-cn) and traditional (zh-tw).