### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,15 +826,12 @@ dependencies = [
 name = "cosmic-launcher"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-stream",
  "console-subscriber",
  "freedesktop-desktop-entry",
  "freedesktop-icons",
  "futures",
- "glob",
  "i18n-embed",
- "i18n-embed-fl",
  "libcosmic",
  "nix 0.27.1",
  "once_cell",
@@ -1028,19 +1025,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.2",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -1738,12 +1722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "glow"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,28 +2021,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "rust-embed",
  "thiserror",
- "unic-langid",
- "walkdir",
-]
-
-[[package]]
-name = "i18n-embed-fl"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a3d3569737dfaac7fc1c4078e6af07471c3060b8e570bcd83cdd5f4685395"
-dependencies = [
- "dashmap",
- "find-crate",
- "fluent",
- "fluent-syntax",
- "i18n-config",
- "i18n-embed",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.38",
  "unic-langid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,12 @@ authors = ["Ashley Wulber <ashley@system76.com>"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
 async-stream = "0.3.5"
 console-subscriber = "0.1.9"
 freedesktop-desktop-entry = "0.5.0"
 freedesktop-icons = "0.2.3"
 futures = "0.3.21"
-glob = "0.3.1"
 i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-requester"] }
-i18n-embed-fl = "0.6.4"
 libcosmic = { git = "https://github.com/pop-os/libcosmic/", default-features = false, features = ["wayland", "tokio"] }
 # libcosmic = { path = "../libcosmic", default-features = false, features = ["wayland", "tokio"] }
 tracing = "0.1"


### PR DESCRIPTION
Three dependencies (`anyhow`, `glob`, and `i18n-embed-fl`) are currently unused. This slows down compilation unnecessarily.