### PR TITLE
Remove redundant Ukrainian translation directory

### DIFF
--- a/uk/cosmic_launcher.ftl
+++ b/uk/cosmic_launcher.ftl
@@ -1,1 +1,0 @@
-app-name = Запускач Cosmic


### PR DESCRIPTION
It was accidentally pushed to the root directory (PR #81) but now, thanks to @wash2 , file is in the appropriate location (https://github.com/pop-os/cosmic-launcher/commit/352489d).