### PR TITLE
fix: changes to make launcher compile again

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -617,9 +617,14 @@ impl cosmic::Application for CosmicLauncher {
                             active: Box::new(|focused, theme| {
                                 let rad_s = theme.cosmic().corner_radii.radius_s;
                                 let a = if focused {
-                                    button::StyleSheet::hovered(theme, focused, &Button::Text)
+                                    button::StyleSheet::hovered(
+                                        theme,
+                                        focused,
+                                        false,
+                                        &Button::Text,
+                                    )
                                 } else {
-                                    button::StyleSheet::active(theme, focused, &Button::Text)
+                                    button::StyleSheet::active(theme, focused, true, &Button::Text)
                                 };
                                 button::Appearance {
                                     border_radius: rad_s.into(),
@@ -629,8 +634,12 @@ impl cosmic::Application for CosmicLauncher {
                             hovered: Box::new(|focused, theme| {
                                 let rad_s = theme.cosmic().corner_radii.radius_s;
 
-                                let text =
-                                    button::StyleSheet::hovered(theme, focused, &Button::Text);
+                                let text = button::StyleSheet::hovered(
+                                    theme,
+                                    focused,
+                                    false,
+                                    &Button::Text,
+                                );
                                 button::Appearance {
                                     border_radius: rad_s.into(),
                                     ..text
@@ -648,8 +657,12 @@ impl cosmic::Application for CosmicLauncher {
                             pressed: Box::new(|focused, theme| {
                                 let rad_s = theme.cosmic().corner_radii.radius_s;
 
-                                let text =
-                                    button::StyleSheet::pressed(theme, focused, &Button::Text);
+                                let text = button::StyleSheet::pressed(
+                                    theme,
+                                    focused,
+                                    true,
+                                    &Button::Text,
+                                );
                                 button::Appearance {
                                     border_radius: rad_s.into(),
                                     ..text


### PR DESCRIPTION
When bumping libcosmic, it somehow left me that I needed to compile to check if changes had been made to other functions since libcosmic had last been bumped. Rest assured I've learned my lesson.

Questions:
* I don't quite understand Box::new and how that's working, so there might be a better way to define the selected parameter for `button::StyleSheet::pressed`, `button::StyleSheet::hovered`, `button::StyleSheet::active`, etc.

cc: @wash2 