### PR TITLE
feat(i18n): Add Indonesian translation for Cosmic Launcher

### DIFF
--- a/i18n/id/cosmic_launcher.ftl
+++ b/i18n/id/cosmic_launcher.ftl
@@ -1,0 +1,1 @@
+app-name = Peluncur Cosmic


### PR DESCRIPTION
## Summary

This PR introduces the Indonesian translation for the term "Cosmic Launcher," translating it as "Peluncur Cosmic" This change aims to improve the user experience for Indonesian users by providing a localized version of the launcher’s name that is culturally and technically relevant.

The term "Peluncur" was chosen as it accurately reflects the functionality of a desktop launcher service in the context of Linux OS.