### PR TITLE
Remove duplicate nix `buildInputs` entry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,6 @@
             lld
             desktop-file-utils
             stdenv.cc.cc.lib
-            desktop-file-utils
            ];
           runtimeDependencies = with pkgs; [
             wayland


### PR DESCRIPTION
This PR reverts a mistake made in https://github.com/pop-os/cosmic-launcher/commit/9990812cb1e6d7e0dab8c1f4b141a14184a261d8 which added a duplicate line of nix `buildInputs` entry.