### PR TITLE
Add vscode extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "bbenoist.nix",
+    "github.vscode-pull-request-github",
+    "macabeus.vscode-fluent",
+    "rust-lang.rust-analyzer",
+    "skellock.just",
+  ]
+}


### PR DESCRIPTION
This PR adds vscode workspace extension recommendations. Some Rust-related extensions such as [`serayuzgur.crates`](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) was left out intentionally since rust development setup vary from person to person.