### PR TITLE
desktop-file: remove ICED as a category

### DIFF
--- a/data/com.system76.CosmicLauncher.desktop
+++ b/data/com.system76.CosmicLauncher.desktop
@@ -4,7 +4,7 @@ Comment=COSMIC Launcher
 Type=Application
 Exec=cosmic-launcher
 Terminal=false
-Categories=COSMIC;ICED;
+Categories=COSMIC;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=COSMIC;ICED;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!


### PR DESCRIPTION
I am working on patches to get COSMIC added as a category in [xdg-specs](https://gitlab.freedesktop.org/xdg/xdg-specs)

I've been told though, that toolkit categories (i.e. GTK, Qt, etc) are essentially deprecated, and not really useful to add.

As a result, to pass desktop file validation, we should remove ICED as a category. We can leave COSMIC, as that will (hopefully soon) be a valid category.