### PR TITLE
Cycle backwards with Shift

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -146,6 +146,7 @@ pub enum Message {
     InputChanged(String),
     Backspace,
     TabPress,
+    ShiftTabPress,
     CompleteFocusedId(Id),
     Activate(Option<usize>),
     Context(usize),
@@ -307,6 +308,10 @@ impl cosmic::Application for CosmicLauncher {
                 ));
             }
             Message::TabPress => {}
+            Message::ShiftTabPress if self.alt_tab => {
+                self.focus_previous();
+            }
+            Message::ShiftTabPress => {}
             Message::CompleteFocusedId(id) => {
                 let i = RESULT_IDS
                     .iter()
@@ -876,7 +881,6 @@ impl cosmic::Application for CosmicLauncher {
                 },
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                     key,
-                    text,
                     modifiers,
                     ..
                 }) => match key {
@@ -900,6 +904,7 @@ impl cosmic::Application for CosmicLauncher {
                         Some(Message::KeyboardNav(keyboard_nav::Message::FocusNext))
                     }
                     Key::Named(Named::Escape) => Some(Message::Hide),
+                    Key::Named(Named::Tab) if modifiers.shift() => Some(Message::ShiftTabPress),
                     Key::Named(Named::Tab) => Some(Message::TabPress),
                     Key::Named(Named::Backspace)
                         if matches!(status, Status::Ignored) && modifiers.is_empty() =>


### PR DESCRIPTION
This should fix #173 and pop-os/cosmic-comp#727.
The reason for a new message is that it could be potentially used in the future to e.g. undo the last Tab autocomplete.
It's possibly not the best way to do this, but it seems to work.

Unrelated, it seems the reason for the extra vertical padding between buttons and dividers is the divider. Changing it to horizontal_rule eliminates the extra vertical padding. Not sure if it should be changed to horizontal rule, or if the divider in libcosmic should be somehow changed.