### PR TITLE
feat: enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ switcheroo-control = { git = "https://github.com/pop-os/dbus-settings-bindings" 
 zbus = { version = "4.2.1", default-features = false, features = ["tokio"] }
 unicode-truncate = "1.0.0"
 unicode-width = "0.1.11"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Hi!

I started a discussion about enabling Link-Time Optimization (LTO) across all pop!_os projects to improve their general performance (more compiler optimizations can be done with LTO) and the binary size reduction (LTO usually leads to measurable binary size improvements) here - https://github.com/pop-os/pop/discussions/3386 . In https://github.com/pop-os/pop/discussions/3386#discussioncomment-10909426 was proposed creating PRs into repos with enabling LTO - it's such a PR!

As a reference, I used the `cosmic-comp` Release [profile](https://github.com/pop-os/cosmic-comp/blob/master/Cargo.toml#L116).

I have made local quick build tests (Fedora 40, Rustc 1.80): the binary size from enabling `lto = "fat"` is dropped from 24 Mib to 18 Mib.

Thank you.