### PR TITLE
fix: restore old alt-tab behaviour

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -484,8 +484,11 @@ impl cosmic::Application for CosmicLauncher {
                         }
                     }
                     pop_launcher::Response::Update(mut list) => {
-                        if self.alt_tab && list.is_empty() {
-                            return self.hide();
+                        if self.alt_tab {
+                            if list.is_empty() {
+                                return self.hide();
+                            }
+                            list.reverse();
                         }
                         list.sort_by(|a, b| {
                             let a = i32::from(a.window.is_none());


### PR DESCRIPTION
After https://github.com/pop-os/launcher/commit/8d9da92dbae520b37ab93fc2364a01d7adbd2f29, `pop_launcher` is now returning the current open windows in reverse order of focus, which messed up the alt-tab behaviour.

To fix this, all that's needed is to reverse the new window list here (or reverse on `pop_launcher`).

Closes #291