### PR TITLE
launcher: crisp category/app icons; size-aware themed lookup; prefer SVG only for -symbolic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -806,7 +806,7 @@ impl cosmic::Application for CosmicLauncher {
                                 IconSource::Name(name) | IconSource::Mime(name) => name,
                             };
                             button_content.push(
-                                icon(from_name(name.clone()).into())
+                                icon(from_name(name.clone()).symbolic(true).size(16).into())
                                     .width(Length::Fixed(16.0))
                                     .height(Length::Fixed(16.0))
                                     .class(cosmic::theme::Svg::Custom(Rc::new(|theme| {


### PR DESCRIPTION
Category icons: symbolic + prefer_svg + size(16).
App icons: size-aware themed lookup; only prefer SVG for -symbolic; full-color app icons prefer raster. Addresses fuzzy/aliased icons.