### PR TITLE
fix: use discrete GPU when more powerful GPU is requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#87c3c35666b926a24a1e8045fd70be2db1145e34"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
 dependencies = [
  "zbus 5.13.1",
 ]
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "switcheroo-control"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#87c3c35666b926a24a1e8045fd70be2db1145e34"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
 dependencies = [
  "zbus 5.13.1",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -306,7 +306,7 @@ async fn try_get_gpu_envs(gpu: GpuPreference) -> Option<HashMap<String, String>>
     let gpus = proxy.get_gpus().await.ok()?;
     match gpu {
         GpuPreference::Default => gpus.into_iter().find(|gpu| gpu.default),
-        GpuPreference::NonDefault => gpus.into_iter().find(|gpu| !gpu.default),
+        GpuPreference::NonDefault => gpus.into_iter().find(|gpu| gpu.discrete),
         GpuPreference::SpecificIdx(idx) => gpus.into_iter().nth(idx as usize),
     }
     .map(|gpu| gpu.environment)


### PR DESCRIPTION
requires https://github.com/pop-os/dbus-settings-bindings/pull/29

Uses a discrete GPU when a more powerful GPU is requested using `PrefersNonDefaultGPU`

> PrefersNonDefaultGPU
> If true, the application prefers to be run on a more powerful discrete GPU if available, which we describe as “a GPU other than the default one” in this spec to avoid the need to define what a discrete GPU is and in which cases it might be considered more powerful than the default GPU. This key is only a hint and support might not be present depending on the implementation. 

https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html

---

Gnome and KDE (and Cinnamon) disagree how the check should be
KDE (and Cinnamon) prefer a Default Discrete GPU and otherwise use the first Discrete GPU
GNOME uses the first Non Default Discrete GPU and otherwise any Discrete GPU
I'll leave deciding this to someone else though I think the way KDE did it is best for usability.