### PR TITLE
fix/cosmic-epoch #2138: Custom shortcuts for "Switch between open windows" don't auto-dismiss on modifier release

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1121,6 +1121,9 @@ impl cosmic::Application for CosmicLauncher {
                         Some(Message::KeyboardNav(keyboard_nav::Action::FocusNext))
                     }
                     Key::Named(Named::Escape) => Some(Message::Hide),
+                    Key::Named(Named::Tab) if modifiers.shift() => {
+                        Some(Message::ShiftAltTab)
+                    }
                     Key::Named(Named::Tab) => Some(Message::TabPress),
                     Key::Named(Named::Backspace)
                         if matches!(status, Status::Ignored) && modifiers.is_empty() =>

--- a/src/app.rs
+++ b/src/app.rs
@@ -187,7 +187,7 @@ pub enum Message {
     AltTab,
     ShiftAltTab,
     Opened(Size, window::Id),
-    AltRelease,
+    ModifierRelease(iced::keyboard::Modifiers),
     Overlap(OverlapNotifyEvent),
     Surface(surface::Action),
 }
@@ -699,8 +699,8 @@ impl cosmic::Application for CosmicLauncher {
                     },
                 ));
             }
-            Message::AltRelease => {
-                if self.alt_tab {
+            Message::ModifierRelease(modifiers) => {
+                if self.alt_tab && modifiers.is_empty() {
                     return self.update(Message::Activate(None));
                 }
             }
@@ -1092,9 +1092,10 @@ impl cosmic::Application for CosmicLauncher {
                     wayland::Event::OverlapNotify(event, ..),
                 )) => Some(Message::Overlap(event)),
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyReleased {
-                    key: Key::Named(Named::Alt | Named::Super),
+                    key: Key::Named(Named::Alt | Named::Super | Named::Control | Named::Shift),
+                    modifiers,
                     ..
-                }) => Some(Message::AltRelease),
+                }) => Some(Message::ModifierRelease(modifiers)),
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                     key,
                     text: _,

--- a/src/app.rs
+++ b/src/app.rs
@@ -187,7 +187,7 @@ pub enum Message {
     AltTab,
     ShiftAltTab,
     Opened(Size, window::Id),
-    ModifierRelease(iced::keyboard::Modifiers),
+    ModifierRelease,
     Overlap(OverlapNotifyEvent),
     Surface(surface::Action),
 }
@@ -699,8 +699,8 @@ impl cosmic::Application for CosmicLauncher {
                     },
                 ));
             }
-            Message::ModifierRelease(modifiers) => {
-                if self.alt_tab && modifiers.is_empty() {
+            Message::ModifierRelease => {
+                if self.alt_tab {
                     return self.update(Message::Activate(None));
                 }
             }
@@ -1092,10 +1092,9 @@ impl cosmic::Application for CosmicLauncher {
                     wayland::Event::OverlapNotify(event, ..),
                 )) => Some(Message::Overlap(event)),
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyReleased {
-                    key: Key::Named(Named::Alt | Named::Super | Named::Control | Named::Shift),
-                    modifiers,
+                    key: Key::Named(Named::Alt | Named::Super | Named::Control),
                     ..
-                }) => Some(Message::ModifierRelease(modifiers)),
+                }) => Some(Message::ModifierRelease),
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                     key,
                     text: _,


### PR DESCRIPTION
Cosmic-Launcher only looked for Alt and Super key releases on custom shortcuts, which broke as soon as you defined Ctrl Key for switching between windows. This fix extends from AltRelease to ModifierRelease and handles all three modifier keys as well as the reversed direction using Modifier+Alt+Shift. 

I used Claude Code for the exploration in the codebase and cross-referencing if the change has an impact on any other pop-os repositories.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

