### PR TITLE
fix: recreate dummy layer surface when closed to keep the clipboard connected

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use cosmic::iced::platform_specific::shell::commands::layer_surface::{
 };
 use cosmic::iced::platform_specific::shell::commands::{self};
 use cosmic::iced::platform_specific::shell::wayland::commands::overlap_notify::overlap_notify;
-use cosmic::iced::runtime::core::event::wayland::LayerEvent;
+use cosmic::iced::runtime::core::event::wayland::{LayerEvent, OutputEvent};
 use cosmic::iced::runtime::core::event::{PlatformSpecific, wayland};
 use cosmic::iced::runtime::core::layout::Limits;
 use cosmic::iced::runtime::core::window::{Event as WindowEvent, Id as SurfaceId};
@@ -160,7 +160,7 @@ pub struct CosmicLauncher {
     height: f32,
     needs_clear: bool,
     hand_over: String,
-    dummy_id: window::Id,
+    dummy_id: Option<window::Id>,
 }
 
 #[derive(Debug, Clone)]
@@ -177,6 +177,7 @@ pub enum Message {
     Hide,
     LauncherEvent(launcher::Event),
     Layer(LayerEvent, window::Id),
+    Output(OutputEvent),
     KeyboardNav(keyboard_nav::Action),
     ActivationToken(Option<String>, String, String, GpuPreference, bool),
     AltTab,
@@ -199,7 +200,9 @@ impl CosmicLauncher {
         }
     }
 
-    fn create_dummy_layer_surface(id: window::Id) -> Task<Message> {
+    fn create_dummy_layer_surface(&mut self) -> Task<Message> {
+        let id = window::Id::unique();
+        self.dummy_id = Some(id);
         get_layer_surface(SctkLayerSurfaceSettings {
             id,
             layer: wlr_layer::Layer::Bottom,
@@ -337,37 +340,35 @@ impl cosmic::Application for CosmicLauncher {
     const APP_ID: &'static str = "com.system76.CosmicLauncher";
 
     fn init(mut core: Core, _flags: Args) -> (Self, Task<Message>) {
-        let dummy_id = window::Id::unique();
-
         core.set_keyboard_nav(false);
-        (
-            CosmicLauncher {
-                core,
-                input_value: String::new(),
-                surface_state: SurfaceState::Hidden,
-                launcher_items: Vec::new(),
-                launcher_item_icon_handles: Vec::new(),
-                tx: None,
-                menu: None,
-                cursor_position: None,
-                focused: 0,
-                last_hide: Instant::now(),
-                alt_tab: false,
-                alt_tab_released: false,
-                window_id: SurfaceId::unique(),
-                queue: VecDeque::new(),
-                result_ids: (0..10)
-                    .map(|id| Id::new(id.to_string()))
-                    .collect::<Vec<_>>(),
-                margin: 0.,
-                overlap: HashMap::new(),
-                height: 100.,
-                needs_clear: false,
-                hand_over: String::default(),
-                dummy_id,
-            },
-            Self::create_dummy_layer_surface(dummy_id),
-        )
+
+        let mut app = CosmicLauncher {
+            core,
+            input_value: String::new(),
+            surface_state: SurfaceState::Hidden,
+            launcher_items: Vec::new(),
+            launcher_item_icon_handles: Vec::new(),
+            tx: None,
+            menu: None,
+            cursor_position: None,
+            focused: 0,
+            last_hide: Instant::now(),
+            alt_tab: false,
+            alt_tab_released: false,
+            window_id: SurfaceId::unique(),
+            queue: VecDeque::new(),
+            result_ids: (0..10)
+                .map(|id| Id::new(id.to_string()))
+                .collect::<Vec<_>>(),
+            margin: 0.,
+            overlap: HashMap::new(),
+            height: 100.,
+            needs_clear: false,
+            hand_over: String::default(),
+            dummy_id: None,
+        };
+        let task = app.create_dummy_layer_surface();
+        (app, task)
     }
 
     fn core(&self) -> &Core {
@@ -616,9 +617,15 @@ impl cosmic::Application for CosmicLauncher {
                     }
                 },
             },
-            Message::Layer(LayerEvent::Done, id) if id == self.dummy_id => {
-                self.dummy_id = window::Id::unique();
-                return Self::create_dummy_layer_surface(self.dummy_id);
+            Message::Layer(LayerEvent::Done, id) if self.dummy_id == Some(id) => {
+                self.dummy_id = None;
+            }
+            Message::Output(event) => {
+                if matches!(event, OutputEvent::Created(_) | OutputEvent::InfoUpdate(_))
+                    && self.dummy_id.is_none()
+                {
+                    return self.create_dummy_layer_surface();
+                }
             }
             Message::Layer(_, id) if id != self.window_id => {}
             Message::Layer(e, _) => match e {
@@ -1147,6 +1154,9 @@ impl cosmic::Application for CosmicLauncher {
                 cosmic::iced::Event::PlatformSpecific(PlatformSpecific::Wayland(
                     wayland::Event::OverlapNotify(event, ..),
                 )) => Some(Message::Overlap(event)),
+                cosmic::iced::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::Output(event, _),
+                )) => Some(Message::Output(event)),
                 cosmic::iced::Event::Keyboard(iced::keyboard::Event::KeyReleased {
                     key: Key::Named(Named::Alt | Named::Super),
                     ..

--- a/src/app.rs
+++ b/src/app.rs
@@ -199,6 +199,23 @@ impl CosmicLauncher {
         }
     }
 
+    fn create_dummy_layer_surface(id: window::Id) -> Task<Message> {
+        get_layer_surface(SctkLayerSurfaceSettings {
+            id,
+            layer: wlr_layer::Layer::Bottom,
+            keyboard_interactivity: wlr_layer::KeyboardInteractivity::None,
+            input_zone: Some(Vec::new()),
+            anchor: wlr_layer::Anchor::empty(),
+            output:
+                cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::Active,
+            namespace: "cosmic_launcher_dummy".into(),
+            margin: IcedMargin::default(),
+            size: Some((Some(6), Some(6))),
+            exclusive_zone: -1,
+            size_limits: Limits::NONE,
+        })
+    }
+
     fn show(&mut self) -> Task<Message> {
         self.surface_state = SurfaceState::Visible;
         self.needs_clear = true;
@@ -347,22 +364,9 @@ impl cosmic::Application for CosmicLauncher {
                 height: 100.,
                 needs_clear: false,
                 hand_over: String::default(),
-                                dummy_id,
-
+                dummy_id,
             },
-            get_layer_surface(SctkLayerSurfaceSettings {
-                id: dummy_id,
-                layer: wlr_layer::Layer::Bottom,
-                keyboard_interactivity: wlr_layer::KeyboardInteractivity::None,
-                input_zone: Some(Vec::new()),
-                anchor: wlr_layer::Anchor::empty(),
-                output: cosmic::iced::runtime::platform_specific::wayland::layer_surface::IcedOutput::Active,
-                namespace: "cosmic_launcher_dummy".into(),
-                margin: IcedMargin::default(),
-                size: Some((Some(6), Some(6))),
-                exclusive_zone: -1,
-                size_limits: Limits::NONE,
-            }),
+            Self::create_dummy_layer_surface(dummy_id),
         )
     }
 
@@ -612,6 +616,10 @@ impl cosmic::Application for CosmicLauncher {
                     }
                 },
             },
+            Message::Layer(LayerEvent::Done, id) if id == self.dummy_id => {
+                self.dummy_id = window::Id::unique();
+                return Self::create_dummy_layer_surface(self.dummy_id);
+            }
             Message::Layer(_, id) if id != self.window_id => {}
             Message::Layer(e, _) => match e {
                 LayerEvent::Focused | LayerEvent::Done => {}


### PR DESCRIPTION
Fixes: 
- https://github.com/pop-os/cosmic-launcher/issues/419, 
- https://github.com/pop-os/cosmic-launcher/issues/420
- https://github.com/pop-os/cosmic-comp/issues/2238

Probably issues like these as well:
- https://github.com/pop-os/cosmic-epoch/issues/3562

The clipboard stops working after the active output is reconfigured (monitor sleep/DPMS, mode change), and from then on, the launcher leaks `wl_data_offer`s for the rest of the session.

**Root cause**: 
- In `init,` the launcher creates a tiny invisible "dummy" layer surface. libcosmic binds the clipboard worker to the first surface created - this dummy, keeping it alive while the UI is hidden.
- When the output is reconfigured, the compositor closes the dummy (`LayerEvent::Done`), so libcosmic drops the clipboard and stops the worker.
- The launcher swallowed `Done` for every surface except `window_id`, so the dummy was never recreated.
- The clipboard then rebinds to the short-lived switcher surface on each show, and every hide orphans its `wl_data_device`, the compositor keeps creating offers that nobody destroys, so the offer `destroyed` count stays frozen while `created` grows to infinity.
- The leaked offers never free their wl_data_offer IDs. Eventually, the compositor reuses an ID that is still in use, and the client rejects it as an invalid new object ID.
- cosmic-session then loops on that error at 100% CPU, and the desktop freezes.

**Fix:**
- Extracted `create_dummy_layer_surface(id)` so the dummy surface settings live in one place (used by both `init` and the new handler).
- Added a `LayerEvent::Done` arm that recreates the dummy with a fresh window ID. libcosmic reconnects the clipboard to the new dummy on creation.
- Everything else is unchanged.

As a result, there are no OOM issues, alt/super+tab issues, or frozen UI anymore.

**What I've tested** (instrumented with logging the smithay-clipboard worker lifecycle):
- Run launcher -> toggle monitor power off (reconfiguration trigger) -> the worker is recreated immediately after destroying.
- The recreated worker stays alive and stable afterward.
- Alt-tab regression: show/hide cycles -> the switcher works as expected, and the clipboard worker keeps running after restart, destroying offers, not keeping them alive indefinitely.

**What I didn't test:**
- Hot-unplugging on a multi-monitor setup (I don't have such hw setup). Yet, it should still work.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.