### PR TITLE
Add workspace-scoped window switcher activation modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,7 +4333,6 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 [[package]]
 name = "pop-launcher"
 version = "1.2.7"
-source = "git+https://github.com/pop-os/launcher/#5b868510716673b31a650488401489898352e2d9"
 dependencies = [
  "const_format",
  "dirs",
@@ -4348,7 +4347,6 @@ dependencies = [
 [[package]]
 name = "pop-launcher-service"
 version = "1.2.7"
-source = "git+https://github.com/pop-os/launcher/#5b868510716673b31a650488401489898352e2d9"
 dependencies = [
  "async-oneshot",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,6 +4333,7 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 [[package]]
 name = "pop-launcher"
 version = "1.2.7"
+source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#6417ea344128af71840de670d6b50081467cc20e"
 dependencies = [
  "const_format",
  "dirs",
@@ -4347,6 +4348,7 @@ dependencies = [
 [[package]]
 name = "pop-launcher-service"
 version = "1.2.7"
+source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#6417ea344128af71840de670d6b50081467cc20e"
 dependencies = [
  "async-oneshot",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1666,7 +1666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3199,7 +3199,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4333,7 +4333,7 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 [[package]]
 name = "pop-launcher"
 version = "1.2.7"
-source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#6417ea344128af71840de670d6b50081467cc20e"
+source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#9193a30fa363da3a9dcb508bab468e0e884b5bda"
 dependencies = [
  "const_format",
  "dirs",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pop-launcher-service"
 version = "1.2.7"
-source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#6417ea344128af71840de670d6b50081467cc20e"
+source = "git+https://github.com/erik-balfe/launcher?branch=feature%2Fworkspace-filtered-window-search#9193a30fa363da3a9dcb508bab468e0e884b5bda"
 dependencies = [
  "async-oneshot",
  "async-trait",
@@ -4888,7 +4888,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5240,7 +5240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5418,7 +5418,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5840,7 +5840,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6518,7 +6518,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,11 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 tracing-journald = "0.3.2"
 tokio-stream = "0.1.18"
 nix = { version = "0.31.1", features = ["process"] }
-pop-launcher = { path = "../pop-launcher" }
-pop-launcher-service = { path = "../pop-launcher/service" }
-# pop-launcher = { git = "https://github.com/pop-os/launcher/" }
-# pop-launcher-service = { git = "https://github.com/pop-os/launcher/" }
+pop-launcher = { git = "https://github.com/erik-balfe/launcher", branch = "feature/workspace-filtered-window-search" }
+pop-launcher-service = { git = "https://github.com/erik-balfe/launcher", branch = "feature/workspace-filtered-window-search" }
+# Local dev override:
+# pop-launcher = { path = "../pop-launcher" }
+# pop-launcher-service = { path = "../pop-launcher/service" }
 rust-embed = "8.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,10 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 tracing-journald = "0.3.2"
 tokio-stream = "0.1.18"
 nix = { version = "0.31.1", features = ["process"] }
-pop-launcher = { git = "https://github.com/pop-os/launcher/" }
-pop-launcher-service = { git = "https://github.com/pop-os/launcher/" }
+pop-launcher = { path = "../pop-launcher" }
+pop-launcher-service = { path = "../pop-launcher/service" }
+# pop-launcher = { git = "https://github.com/pop-os/launcher/" }
+# pop-launcher-service = { git = "https://github.com/pop-os/launcher/" }
 rust-embed = "8.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/data/cosmic/com.system76.CosmicLauncher/v1/window_switcher
+++ b/data/cosmic/com.system76.CosmicLauncher/v1/window_switcher
@@ -1,0 +1,3 @@
+(
+    default_scope: all,
+)

--- a/data/justfile
+++ b/data/justfile
@@ -7,9 +7,13 @@ desktop-dst := install-dir / 'applications' / desktop-src
 metainfo-src := appid + '.metainfo.xml'
 metainfo-dst := install-dir / 'metainfo' / metainfo-src
 
+window-switcher-src := 'cosmic' / appid / 'v1' / 'window_switcher'
+window-switcher-dst := install-dir / 'cosmic' / appid / 'v1' / 'window_switcher'
+
 install:
     install -Dm0644 {{desktop-src}} {{desktop-dst}}
     install -Dm0644 {{metainfo-src}} {{metainfo-dst}}
+    install -Dm0644 {{window-switcher-src}} {{window-switcher-dst}}
 
 uninstall:
-    rm {{desktop-dst}} {{metainfo-dst}}
+    rm {{desktop-dst}} {{metainfo-dst}} {{window-switcher-dst}}

--- a/debian/install
+++ b/debian/install
@@ -3,3 +3,4 @@
 /usr/share/icons/hicolor/scalable/apps/com.system76.CosmicLauncher.svg
 /usr/share/icons/hicolor/symbolic/apps/com.system76.CosmicLauncher-symbolic.svg
 /usr/share/metainfo/com.system76.CosmicLauncher.metainfo.xml
+data/cosmic/com.system76.CosmicLauncher/v1/window_switcher

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,6 +155,51 @@ impl FromStr for LauncherTasks {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_launcher_action_accepts_kebab_case() {
+        assert!(matches!(
+            parse_launcher_action("alt-tab-workspace", &[]),
+            Ok(LauncherTasks::AltTabWorkspace)
+        ));
+    }
+
+    #[test]
+    fn parse_launcher_action_accepts_json_variant() {
+        assert!(matches!(
+            parse_launcher_action("\"AltTabAll\"", &[]),
+            Ok(LauncherTasks::AltTabAll)
+        ));
+    }
+
+    #[test]
+    fn parse_launcher_action_accepts_input_with_args() {
+        let cmd = parse_launcher_action("Input", &["firefox".into()]).unwrap();
+        assert!(matches!(
+            cmd,
+            LauncherTasks::Input {
+                input: Some(ref value)
+            } if value == "firefox"
+        ));
+    }
+
+    #[test]
+    fn workspace_filter_maps_alt_tab_to_config_default() {
+        let config = WindowSwitcher::default();
+        assert_eq!(
+            LauncherTasks::AltTab.workspace_filter(&config),
+            WorkspaceFilter::All
+        );
+        assert_eq!(
+            LauncherTasks::AltTabWorkspace.workspace_filter(&config),
+            WorkspaceFilter::Current
+        );
+    }
+}
+
 impl CosmicFlags for Args {
     type SubCommand = LauncherTasks;
     type Args = Vec<String>;

--- a/src/app.rs
+++ b/src/app.rs
@@ -119,35 +119,39 @@ impl Display for LauncherTasks {
     }
 }
 
+fn parse_launcher_action(action: &str, args: &[String]) -> Result<LauncherTasks, serde_json::Error> {
+    if let Ok(cmd) = serde_json::de::from_str(action) {
+        return Ok(cmd);
+    }
+
+    let variant = action.trim_matches('"');
+    match variant {
+        "alt-tab" => Ok(LauncherTasks::AltTab),
+        "alt-tab-all" => Ok(LauncherTasks::AltTabAll),
+        "alt-tab-workspace" => Ok(LauncherTasks::AltTabWorkspace),
+        "shift-alt-tab" => Ok(LauncherTasks::ShiftAltTab),
+        "shift-alt-tab-all" => Ok(LauncherTasks::ShiftAltTabAll),
+        "shift-alt-tab-workspace" => Ok(LauncherTasks::ShiftAltTabWorkspace),
+        "AltTab" => Ok(LauncherTasks::AltTab),
+        "AltTabAll" => Ok(LauncherTasks::AltTabAll),
+        "AltTabWorkspace" => Ok(LauncherTasks::AltTabWorkspace),
+        "ShiftAltTab" => Ok(LauncherTasks::ShiftAltTab),
+        "ShiftAltTabAll" => Ok(LauncherTasks::ShiftAltTabAll),
+        "ShiftAltTabWorkspace" => Ok(LauncherTasks::ShiftAltTabWorkspace),
+        "Input" | "input" => Ok(LauncherTasks::Input {
+            input: args.first().cloned().filter(|input| !input.is_empty()),
+        }),
+        "Close" | "close" => Ok(LauncherTasks::Close),
+        other if other.starts_with('"') => serde_json::de::from_str(other),
+        other => serde_json::de::from_str(&format!("\"{other}\"")),
+    }
+}
+
 impl FromStr for LauncherTasks {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(cmd) = serde_json::de::from_str(s) {
-            return Ok(cmd);
-        }
-
-        let variant = s.trim_matches('"');
-        let json = match variant {
-            "alt-tab" => "\"AltTab\"",
-            "alt-tab-all" => "\"AltTabAll\"",
-            "alt-tab-workspace" => "\"AltTabWorkspace\"",
-            "shift-alt-tab" => "\"ShiftAltTab\"",
-            "shift-alt-tab-all" => "\"ShiftAltTabAll\"",
-            "shift-alt-tab-workspace" => "\"ShiftAltTabWorkspace\"",
-            "AltTab" => "\"AltTab\"",
-            "AltTabAll" => "\"AltTabAll\"",
-            "AltTabWorkspace" => "\"AltTabWorkspace\"",
-            "ShiftAltTab" => "\"ShiftAltTab\"",
-            "ShiftAltTabAll" => "\"ShiftAltTabAll\"",
-            "ShiftAltTabWorkspace" => "\"ShiftAltTabWorkspace\"",
-            other if other.starts_with('"') => other,
-            other => {
-                return serde_json::de::from_str(&format!("\"{other}\""));
-            }
-        };
-
-        serde_json::de::from_str(json)
+        parse_launcher_action(s, &[])
     }
 }
 
@@ -462,11 +466,11 @@ impl cosmic::Application for CosmicLauncher {
         match message {
             Message::InputChanged(value) => {
                 self.input_value.clone_from(&value);
-                self.request(launcher::Request::Search(value));
+                self.request_search(value);
             }
             Message::Backspace => {
                 self.input_value.pop();
-                self.request(launcher::Request::Search(self.input_value.clone()));
+                self.request_search(self.input_value.clone());
             }
             Message::TabPress if !self.alt_tab => {
                 let focused = self.focused;
@@ -853,16 +857,18 @@ impl cosmic::Application for CosmicLauncher {
                 }
                 // hack: allow to close the launcher from the panel button
                 if self.last_hide.elapsed().as_millis() > 100 {
-                    self.request(launcher::Request::Search(String::new()));
+                    self.alt_tab = false;
+                    self.alt_tab_released = false;
+                    self.request_search(String::new());
 
                     self.surface_state = SurfaceState::WaitingToBeShown;
                     return Task::none();
                 }
             }
-            Details::ActivateAction { action, .. } => {
-                debug!("ActivateAction {}", action);
+            Details::ActivateAction { action, args, .. } => {
+                debug!("ActivateAction {} {:?}", action, args);
 
-                let Ok(cmd) = LauncherTasks::from_str(&action) else {
+                let Ok(cmd) = parse_launcher_action(&action, &args) else {
                     warn!("failed to parse launcher action {:?}", action);
                     return Task::none();
                 };
@@ -931,10 +937,12 @@ impl cosmic::Application for CosmicLauncher {
                         self.queue.push_back(Message::ShiftAltTab);
                     }
                     LauncherTasks::Input { input } => {
-                        self.request(launcher::Request::Search(String::new()));
+                        self.alt_tab = false;
+                        self.alt_tab_released = false;
+                        self.request_search(String::new());
                         if let Some(input) = input {
                             self.hand_over.push_str(&input);
-                        };
+                        }
                     }
                     LauncherTasks::Close => {
                         return self.update(Message::Hide);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::app::iced::event::listen_raw;
+use crate::config::{WindowSwitcher, window_switcher_config};
 use crate::subscriptions::launcher;
 use crate::{components, fl};
 use clap::Parser;
@@ -38,7 +39,7 @@ use cosmic::widget::{autosize, button, divider, icon, id_container, mouse_area, 
 use cosmic::{Element, keyboard_nav, surface};
 use iced::keyboard::{Key, Modifiers};
 use iced::{Alignment, Color};
-use pop_launcher::{ContextOption, GpuPreference, IconSource, SearchResult};
+use pop_launcher::{ContextOption, GpuPreference, IconSource, SearchResult, WorkspaceFilter};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Display;
@@ -48,7 +49,7 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 use std::time::Instant;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, warn};
 
 static AUTOSIZE_ID: LazyLock<Id> = LazyLock::new(|| Id::new("autosize"));
 static MAIN_ID: LazyLock<Id> = LazyLock::new(|| Id::new("main"));
@@ -68,14 +69,48 @@ pub struct Args {
 
 #[derive(Debug, Serialize, Deserialize, Clone, clap::Subcommand)]
 pub enum LauncherTasks {
-    #[clap(about = "Toggle the launcher and switch to the alt-tab view")]
+    #[clap(name = "alt-tab", about = "Toggle the window switcher (configured default scope)")]
     AltTab,
-    #[clap(about = "Toggle the launcher and switch to the alt-tab view")]
+    #[clap(
+        name = "alt-tab-all",
+        about = "Toggle the window switcher across all workspaces"
+    )]
+    AltTabAll,
+    #[clap(
+        name = "alt-tab-workspace",
+        about = "Toggle the window switcher for the current workspace only"
+    )]
+    AltTabWorkspace,
+    #[clap(
+        name = "shift-alt-tab",
+        about = "Toggle the window switcher in reverse (configured default scope)"
+    )]
     ShiftAltTab,
+    #[clap(
+        name = "shift-alt-tab-all",
+        about = "Toggle the window switcher in reverse across all workspaces"
+    )]
+    ShiftAltTabAll,
+    #[clap(
+        name = "shift-alt-tab-workspace",
+        about = "Toggle the window switcher in reverse for the current workspace only"
+    )]
+    ShiftAltTabWorkspace,
     #[clap(about = "Start the launcher with an input")]
     Input { input: Option<String> },
     #[clap(about = "Close the launcher if open")]
     Close,
+}
+
+impl LauncherTasks {
+    pub fn workspace_filter(&self, config: &WindowSwitcher) -> WorkspaceFilter {
+        match self {
+            Self::AltTab | Self::ShiftAltTab => config.default_scope.to_filter(),
+            Self::AltTabAll | Self::ShiftAltTabAll => WorkspaceFilter::All,
+            Self::AltTabWorkspace | Self::ShiftAltTabWorkspace => WorkspaceFilter::Current,
+            Self::Input { .. } | Self::Close => WorkspaceFilter::All,
+        }
+    }
 }
 
 impl Display for LauncherTasks {
@@ -88,7 +123,31 @@ impl FromStr for LauncherTasks {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::de::from_str(s)
+        if let Ok(cmd) = serde_json::de::from_str(s) {
+            return Ok(cmd);
+        }
+
+        let variant = s.trim_matches('"');
+        let json = match variant {
+            "alt-tab" => "\"AltTab\"",
+            "alt-tab-all" => "\"AltTabAll\"",
+            "alt-tab-workspace" => "\"AltTabWorkspace\"",
+            "shift-alt-tab" => "\"ShiftAltTab\"",
+            "shift-alt-tab-all" => "\"ShiftAltTabAll\"",
+            "shift-alt-tab-workspace" => "\"ShiftAltTabWorkspace\"",
+            "AltTab" => "\"AltTab\"",
+            "AltTabAll" => "\"AltTabAll\"",
+            "AltTabWorkspace" => "\"AltTabWorkspace\"",
+            "ShiftAltTab" => "\"ShiftAltTab\"",
+            "ShiftAltTabAll" => "\"ShiftAltTabAll\"",
+            "ShiftAltTabWorkspace" => "\"ShiftAltTabWorkspace\"",
+            other if other.starts_with('"') => other,
+            other => {
+                return serde_json::de::from_str(&format!("\"{other}\""));
+            }
+        };
+
+        serde_json::de::from_str(json)
     }
 }
 
@@ -152,6 +211,8 @@ pub struct CosmicLauncher {
     last_hide: Instant,
     alt_tab: bool,
     alt_tab_released: bool,
+    alt_tab_workspace_filter: WorkspaceFilter,
+    window_switcher_config: WindowSwitcher,
     window_id: window::Id,
     queue: VecDeque<Message>,
     result_ids: Vec<Id>,
@@ -196,7 +257,22 @@ impl CosmicLauncher {
                 error!("tx: {e}");
             }
         } else {
-            info!("tx not found");
+            warn!("tx not found for request {:?}", r);
+        }
+    }
+
+    fn request_search(&self, query: String) {
+        if self.alt_tab {
+            debug!(
+                "window search with workspace filter {:?}",
+                self.alt_tab_workspace_filter
+            );
+            self.request(launcher::Request::SearchFiltered {
+                query,
+                workspace_filter: self.alt_tab_workspace_filter,
+            });
+        } else {
+            self.request(launcher::Request::Search(query));
         }
     }
 
@@ -355,6 +431,8 @@ impl cosmic::Application for CosmicLauncher {
             last_hide: Instant::now(),
             alt_tab: false,
             alt_tab_released: false,
+            alt_tab_workspace_filter: WorkspaceFilter::All,
+            window_switcher_config: window_switcher_config(),
             window_id: SurfaceId::unique(),
             queue: VecDeque::new(),
             result_ids: (0..10)
@@ -453,7 +531,11 @@ impl cosmic::Application for CosmicLauncher {
             Message::LauncherEvent(e) => match e {
                 launcher::Event::Started(tx) => {
                     self.tx.replace(tx);
-                    self.request(launcher::Request::Search(self.input_value.clone()));
+                    if self.alt_tab || self.input_value.is_empty() {
+                        self.request_search(String::new());
+                    } else {
+                        self.request_search(self.input_value.clone());
+                    }
                 }
                 launcher::Event::ServiceIsClosed => {
                     self.request(launcher::Request::ServiceIsClosed);
@@ -613,7 +695,7 @@ impl cosmic::Application for CosmicLauncher {
                     }
                     pop_launcher::Response::Fill(s) => {
                         self.input_value = s;
-                        self.request(launcher::Request::Search(self.input_value.clone()));
+                        self.request_search(self.input_value.clone());
                     }
                 },
             },
@@ -702,7 +784,7 @@ impl cosmic::Application for CosmicLauncher {
                     }
                     keyboard_nav::Action::Escape => {
                         self.input_value.clear();
-                        self.request(launcher::Request::Search(String::new()));
+                        self.request_search(String::new());
                     }
                     _ => {}
                 };
@@ -781,16 +863,33 @@ impl cosmic::Application for CosmicLauncher {
                 debug!("ActivateAction {}", action);
 
                 let Ok(cmd) = LauncherTasks::from_str(&action) else {
+                    warn!("failed to parse launcher action {:?}", action);
                     return Task::none();
                 };
+
+                debug!(
+                    "launcher action {:?} -> workspace filter {:?}",
+                    cmd,
+                    cmd.workspace_filter(&self.window_switcher_config)
+                );
 
                 if self.surface_state == SurfaceState::Hidden {
                     self.surface_state = SurfaceState::WaitingToBeShown;
                 }
 
                 match cmd {
-                    LauncherTasks::AltTab => {
+                    LauncherTasks::AltTab
+                    | LauncherTasks::AltTabAll
+                    | LauncherTasks::AltTabWorkspace => {
+                        let workspace_filter =
+                            cmd.workspace_filter(&self.window_switcher_config);
+                        let filter_changed =
+                            self.alt_tab_workspace_filter != workspace_filter;
+                        self.alt_tab_workspace_filter = workspace_filter;
                         if self.alt_tab {
+                            if filter_changed {
+                                self.request_search(String::new());
+                            }
                             if self.surface_state == SurfaceState::WaitingToBeShown
                                 || self.launcher_items.is_empty()
                             {
@@ -802,11 +901,21 @@ impl cosmic::Application for CosmicLauncher {
 
                         self.alt_tab = true;
                         self.alt_tab_released = false;
-                        self.request(launcher::Request::Search(String::new()));
+                        self.request_search(String::new());
                         self.queue.push_back(Message::AltTab);
                     }
-                    LauncherTasks::ShiftAltTab => {
+                    LauncherTasks::ShiftAltTab
+                    | LauncherTasks::ShiftAltTabAll
+                    | LauncherTasks::ShiftAltTabWorkspace => {
+                        let workspace_filter =
+                            cmd.workspace_filter(&self.window_switcher_config);
+                        let filter_changed =
+                            self.alt_tab_workspace_filter != workspace_filter;
+                        self.alt_tab_workspace_filter = workspace_filter;
                         if self.alt_tab {
+                            if filter_changed {
+                                self.request_search(String::new());
+                            }
                             if self.surface_state == SurfaceState::WaitingToBeShown
                                 || self.launcher_items.is_empty()
                             {
@@ -818,7 +927,7 @@ impl cosmic::Application for CosmicLauncher {
 
                         self.alt_tab = true;
                         self.alt_tab_released = false;
-                        self.request(launcher::Request::Search(String::new()));
+                        self.request_search(String::new());
                         self.queue.push_back(Message::ShiftAltTab);
                     }
                     LauncherTasks::Input { input } => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -323,6 +323,7 @@ impl CosmicLauncher {
         self.focused = 0;
         self.alt_tab = false;
         self.alt_tab_released = false;
+        self.alt_tab_workspace_filter = WorkspaceFilter::All;
         self.queue.clear();
         self.hand_over.clear();
 
@@ -618,7 +619,10 @@ impl cosmic::Application for CosmicLauncher {
                         }
                     }
                     pop_launcher::Response::Update(mut list) => {
-                        if self.alt_tab && list.is_empty() {
+                        if self.alt_tab
+                            && list.is_empty()
+                            && self.alt_tab_workspace_filter != WorkspaceFilter::Current
+                        {
                             return self.hide();
                         }
                         if self.alt_tab || self.input_value.is_empty() {
@@ -630,6 +634,13 @@ impl cosmic::Application for CosmicLauncher {
                             a.cmp(&b)
                         });
                         self.launcher_items.splice(.., list);
+                        if !self.launcher_items.is_empty() {
+                            self.focused = self
+                                .focused
+                                .min(self.launcher_items.len().saturating_sub(1));
+                        } else {
+                            self.focused = 0;
+                        }
                         if self.result_ids.len() < self.launcher_items.len() {
                             self.result_ids.extend(
                                 (self.result_ids.len()..self.launcher_items.len())
@@ -894,7 +905,9 @@ impl cosmic::Application for CosmicLauncher {
                         self.alt_tab_workspace_filter = workspace_filter;
                         if self.alt_tab {
                             if filter_changed {
+                                self.focused = 0;
                                 self.request_search(String::new());
+                                return Task::none();
                             }
                             if self.surface_state == SurfaceState::WaitingToBeShown
                                 || self.launcher_items.is_empty()
@@ -920,7 +933,9 @@ impl cosmic::Application for CosmicLauncher {
                         self.alt_tab_workspace_filter = workspace_filter;
                         if self.alt_tab {
                             if filter_changed {
+                                self.focused = 0;
                                 self.request_search(String::new());
+                                return Task::none();
                             }
                             if self.surface_state == SurfaceState::WaitingToBeShown
                                 || self.launcher_items.is_empty()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,61 @@
+use cosmic::cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
+use pop_launcher::WorkspaceFilter;
+use serde::{Deserialize, Serialize};
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONFIG_VERSION: u64 = 1;
+pub const APP_ID: &str = "com.system76.CosmicLauncher";
 
 pub fn profile() -> &'static str {
     std::env!("OUT_DIR")
         .split(std::path::MAIN_SEPARATOR)
         .nth_back(3)
         .unwrap_or("unknown")
+}
+
+/// Which workspaces the window switcher should include.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceScope {
+    /// List windows from every workspace.
+    #[default]
+    All,
+    /// List only windows on the currently active workspace(s).
+    Current,
+}
+
+impl WorkspaceScope {
+    pub const fn to_filter(self) -> WorkspaceFilter {
+        match self {
+            Self::All => WorkspaceFilter::All,
+            Self::Current => WorkspaceFilter::Current,
+        }
+    }
+}
+
+/// Window switcher defaults for `cosmic-launcher alt-tab`.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, CosmicConfigEntry)]
+#[version = 1]
+pub struct WindowSwitcher {
+    /// Default scope for `cosmic-launcher alt-tab` / `shift-alt-tab`.
+    #[serde(default)]
+    pub default_scope: WorkspaceScope,
+}
+
+impl Default for WindowSwitcher {
+    fn default() -> Self {
+        Self {
+            default_scope: WorkspaceScope::All,
+        }
+    }
+}
+
+pub fn window_switcher_config() -> WindowSwitcher {
+    cosmic_config::Config::new(
+        APP_ID,
+        WindowSwitcher::VERSION,
+    )
+    .ok()
+    .and_then(|config| WindowSwitcher::get_entry(&config).ok())
+    .unwrap_or_default()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
 use cosmic::cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
 use pop_launcher::WorkspaceFilter;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const CONFIG_VERSION: u64 = 1;
 pub const APP_ID: &str = "com.system76.CosmicLauncher";
 
 pub fn profile() -> &'static str {
@@ -51,11 +51,16 @@ impl Default for WindowSwitcher {
 }
 
 pub fn window_switcher_config() -> WindowSwitcher {
-    cosmic_config::Config::new(
-        APP_ID,
-        WindowSwitcher::VERSION,
-    )
-    .ok()
-    .and_then(|config| WindowSwitcher::get_entry(&config).ok())
-    .unwrap_or_default()
+    let Some(config) = cosmic_config::Config::new(APP_ID, WindowSwitcher::VERSION) else {
+        warn!("failed to load window switcher config for {APP_ID}");
+        return WindowSwitcher::default();
+    };
+
+    match WindowSwitcher::get_entry(&config) {
+        Ok(entry) => entry,
+        Err(why) => {
+            warn!("failed to parse window switcher config: {why}");
+            WindowSwitcher::default()
+        }
+    }
 }

--- a/src/subscriptions/launcher.rs
+++ b/src/subscriptions/launcher.rs
@@ -9,6 +9,10 @@ use tokio::sync::{mpsc, oneshot};
 #[derive(Debug, Clone)]
 pub enum Request {
     Search(String),
+    SearchFiltered {
+        query: String,
+        workspace_filter: pop_launcher::WorkspaceFilter,
+    },
     Activate(u32),
     Context(u32),
     Complete(u32),
@@ -108,7 +112,24 @@ pub fn service() -> impl Stream<Item = Event> + MaybeSend {
             match request {
                 Request::Search(s) => {
                     if let Some((client, _)) = client_request(&responses_tx, client) {
+                        tracing::debug!("ipc: Search({s:?})");
                         let _res = client.send(pop_launcher::Request::Search(s)).await;
+                    }
+                }
+                Request::SearchFiltered {
+                    query,
+                    workspace_filter,
+                } => {
+                    if let Some((client, _)) = client_request(&responses_tx, client) {
+                        tracing::debug!(
+                            "ipc: SearchFiltered({query:?}, workspace_filter={workspace_filter:?})"
+                        );
+                        let _res = client
+                            .send(pop_launcher::Request::SearchFiltered {
+                                query,
+                                workspace_filter,
+                            })
+                            .await;
                     }
                 }
                 Request::Activate(i) => {


### PR DESCRIPTION
## Summary

Adds workspace-scoped window switcher activation modes for COSMIC.

- New CLI/dbus actions: `alt-tab-workspace`, `alt-tab-all` (and shift variants)
- `request_search()` routes alt-tab through `SearchFiltered`
- `WindowSwitcher` cosmic-config with `default_scope: all`
- Fixes Super launcher search / `Input` dbus activation regressions

**Stacked dependency:** [pop-os/launcher#290](https://github.com/pop-os/launcher/pull/290). Uses temporary git dep on `erik-balfe/launcher#feature/workspace-filtered-window-search` for review; switch to `pop-os/launcher` rev before merge.

## Testing
- `alt-tab-workspace` / `alt-tab-all` on multiple workspaces
- Super launcher search filters when typing

## Checklist
- [x] AI-assisted; reviewed locally with CodeRabbit CLI + manual testing on COSMIC