### PR TITLE
Reset the results list when the search query changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -447,11 +447,15 @@ impl cosmic::Application for CosmicLauncher {
         match message {
             Message::InputChanged(value) => {
                 self.input_value.clone_from(&value);
+                self.focused = 0;
                 self.request(launcher::Request::Search(value));
+                return operation::snap_to(SCROLLABLE.clone(), RelativeOffset::START);
             }
             Message::Backspace => {
                 self.input_value.pop();
+                self.focused = 0;
                 self.request(launcher::Request::Search(self.input_value.clone()));
+                return operation::snap_to(SCROLLABLE.clone(), RelativeOffset::START);
             }
             Message::TabPress if !self.alt_tab => {
                 let focused = self.focused;


### PR DESCRIPTION
Typing into the launcher updated the results but left the list scrolled where it
was, so the new results stayed out of view until the user scrolled back up.

`InputChanged` and `Backspace` now snap the scrollable back to the top, reusing
the `snap_to` operation the keyboard navigation already uses, and focus the first
result. Without the focus reset the selection would be left on an item that is no
longer visible, and the next keyboard navigation would scroll straight back down
to it.

The scroll is reset where the query changes rather than in `Response::Update`,
since that handler also runs for alt-tab, which does its own `snap_to` to the
focused window.

Fixes #380

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
